### PR TITLE
Added Sophia syntax workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "./sophia-workaround.sh && ng serve",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "./sophia-workaround.sh && ng serve",
-    "build": "ng build",
+    "start": "npm run sophia && ng serve",
+    "build": "npm run sophia && ng build",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "postinstall": "node patch.js"
+    "postinstall": "node patch.js",
+    "sophia": "./sophia-workaround.sh"
   },
   "private": true,
   "dependencies": {

--- a/sophia-workaround.sh
+++ b/sophia-workaround.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+rm -rf ./node_modules/ngx-monaco-editor
+curl -L https://github.com/mradkov/ngx-monaco-editor/releases/download/sophia/ngx-monaco-editor.tar.gz | tar -xz -C ./node_modules/

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -30,7 +30,7 @@ export class EditorComponent implements OnInit {
   contract: Contract<string> = new Contract();
   constructor(private compiler: CompilerService, private controlService: ContractControlService) { }
 
-  editorOptions = {theme: 'vs-dark', language: 'sophia'};
+  editorOptions = {theme: 'vs-dark', language: 'aes'};
 
   ngOnInit() {
     // If the compiler asks for code, give it to him and deploy the contract


### PR DESCRIPTION
Until https://github.com/microsoft/monaco-languages/pull/67 is accepted and introduced in `monaco-editor` (hopefully sooner: https://github.com/microsoft/monaco-editor/pull/1543), I've created a workaround for the Sophia syntax.

Since `ngx-monaco-editor` depends on `monaco-editor` and it depends on the languages in `monaco-languages`. I've built and released a fork of `ngx-monaco-editor` which introduces the changes here: https://github.com/mradkov/ngx-monaco-editor/releases/tag/sophia

The workaround consists of a bash script which is downloading and extracting this release after being run.

I've added `npm run sophia` script which is doing this and added it to the `npm start` and `npm build` scripts as well.

Result:
![изображение](https://user-images.githubusercontent.com/13139371/62818934-1f1c2d80-bb57-11e9-90c7-3ca3ab0b075e.png)
